### PR TITLE
fix: repair release pipeline publishing failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run Snyk vulnerability scan
-        uses: snyk/actions/golang@master
+        uses: snyk/actions/golang@8e119fbb6c251787721d34ba683ed48eba792766 # master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,22 @@ jobs:
 
       - name: Run pinned security scans
         run: just security
+
+  snyk:
+    name: Snyk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run Snyk vulnerability scan
+        uses: snyk/actions/golang@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --file=go.mod --severity-threshold=high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   release:
@@ -20,7 +21,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: "${{ github.event.repository.name }},homebrew-tap"
           permission-contents: write
           permission-packages: write
 
@@ -39,13 +40,13 @@ jobs:
       - name: Run Dagger Release Pipeline
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           VERSION_TAG: ${{ github.ref_name }}
         run: |
           dagger call release \
             --source=. \
             --version="$VERSION_TAG" \
             --github-token=env:GITHUB_TOKEN \
-            --npm-token=env:NPM_TOKEN \
+            --npm-oidc-token-url="$ACTIONS_ID_TOKEN_REQUEST_URL" \
+            --npm-oidc-token=env:ACTIONS_ID_TOKEN_REQUEST_TOKEN \
             --docker-registry=ghcr.io/natonathan/shipyard \
             --docker-username=${{ github.repository_owner }}

--- a/.shipyard/consignments/20260627-170642-nqshc6.md
+++ b/.shipyard/consignments/20260627-170642-nqshc6.md
@@ -6,4 +6,4 @@ packages:
 changeType: patch
 ---
 
-Fix release pipeline: npm OIDC trusted publishing, Homebrew token scope, Docker packages permission
+Fix release pipeline: npm OIDC trusted publishing, Homebrew token scope, Snyk CLI CI job

--- a/.shipyard/consignments/20260627-170642-nqshc6.md
+++ b/.shipyard/consignments/20260627-170642-nqshc6.md
@@ -1,0 +1,9 @@
+---
+id: 20260627-170642-nqshc6
+timestamp: "2026-06-27T17:06:42Z"
+packages:
+    - shipyard
+changeType: patch
+---
+
+Fix release pipeline: npm OIDC trusted publishing, Homebrew token scope, Docker packages permission

--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,0 @@
-# Snyk policy file — https://snyk.io/docs/snyk-cli/
-version: v1.25.0
-ignore: {}
-patch: {}
-exclude:
-  global:
-    # Dagger module uses code-generated packages (internal/dagger, dagger.gen.go)
-    # that are not committed to the repo, so go list fails on this module.
-    - dagger/**

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk policy file — https://snyk.io/docs/snyk-cli/
+version: v1.25.0
+ignore: {}
+patch: {}
+exclude:
+  global:
+    # Dagger module uses code-generated packages (internal/dagger, dagger.gen.go)
+    # that are not committed to the repo, so go list fails on this module.
+    - dagger/**

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 > Chart your project's version journey - manage cargo (changes), navigate to new ports (versions), and maintain your ship's log
 
+[![CI](https://github.com/NatoNathan/shipyard/actions/workflows/ci.yml/badge.svg)](https://github.com/NatoNathan/shipyard/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/natonathan/shipyard)](https://github.com/natonathan/shipyard/releases)
+[![codecov](https://codecov.io/gh/NatoNathan/shipyard/graph/badge.svg)](https://codecov.io/gh/NatoNathan/shipyard)
+[![npm](https://img.shields.io/npm/v/shipyard-cli?label=npm&logo=npm)](https://www.npmjs.com/package/shipyard-cli)
+[![Docker](https://img.shields.io/badge/docker-ghcr.io-blue?logo=docker)](https://github.com/NatoNathan/shipyard/pkgs/container/shipyard)
 [![Go Report](https://img.shields.io/badge/go%20report-A+-brightgreen.svg?style=flat)](https://goreportcard.com/report/github.com/natonathan/shipyard)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/natonathan/shipyard)](https://github.com/natonathan/shipyard/releases)
 
 ## What is Shipyard?
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Chart your project's version journey - manage cargo (changes), navigate to new ports (versions), and maintain your ship's log
 
 [![CI](https://github.com/NatoNathan/shipyard/actions/workflows/ci.yml/badge.svg)](https://github.com/NatoNathan/shipyard/actions/workflows/ci.yml)
+[![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/NatoNathan/shipyard?utm_source=oss&utm_medium=github&utm_campaign=NatoNathan%2Fshipyard&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
 [![Release](https://img.shields.io/github/v/release/natonathan/shipyard)](https://github.com/natonathan/shipyard/releases)
 [![codecov](https://codecov.io/gh/NatoNathan/shipyard/graph/badge.svg)](https://codecov.io/gh/NatoNathan/shipyard)
 [![npm](https://img.shields.io/npm/v/shipyard-cli?label=npm&logo=npm)](https://www.npmjs.com/package/shipyard-cli)

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -40,6 +40,12 @@ func (m *Shipyard) Release(
 	if dockerToken == nil {
 		dockerToken = githubToken
 	}
+	if npmOidcTokenUrl == "" {
+		return fmt.Errorf("npm OIDC token request URL is required")
+	}
+	if npmOidcToken == nil {
+		return fmt.Errorf("npm OIDC token request token is required")
+	}
 
 	// Get commit SHA from git
 	commit, err := dag.Container().

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -23,8 +23,10 @@ func (m *Shipyard) Release(
 	version string,
 	// GitHub token for releases and Docker registry
 	githubToken *dagger.Secret,
-	// npm registry token
-	npmToken *dagger.Secret,
+	// GitHub Actions OIDC token request URL for npm trusted publishing (ACTIONS_ID_TOKEN_REQUEST_URL)
+	npmOidcTokenUrl string,
+	// GitHub Actions OIDC bearer token for npm trusted publishing (ACTIONS_ID_TOKEN_REQUEST_TOKEN)
+	npmOidcToken *dagger.Secret,
 	// Docker registry (e.g., "ghcr.io/natonathan/shipyard")
 	// +default="ghcr.io/natonathan/shipyard"
 	dockerRegistry string,
@@ -89,7 +91,7 @@ func (m *Shipyard) Release(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := m.PublishNPM(ctx, packageArtifacts, version, npmToken); err != nil {
+		if err := m.PublishNPM(ctx, packageArtifacts, version, npmOidcTokenUrl, npmOidcToken); err != nil {
 			errors <- fmt.Errorf("npm: %w", err)
 		}
 	}()

--- a/dagger/publish.go
+++ b/dagger/publish.go
@@ -232,15 +232,17 @@ end
 	)
 }
 
-// PublishNPM publishes the npm wrapper package
+// PublishNPM publishes the npm wrapper package using GitHub Actions OIDC trusted publishing
 func (m *Shipyard) PublishNPM(
 	ctx context.Context,
 	// Package artifacts directory
 	artifacts *dagger.Directory,
 	// Version string (e.g., "v1.2.3")
 	version string,
-	// npm auth token
-	npmToken *dagger.Secret,
+	// GitHub Actions OIDC token request URL (ACTIONS_ID_TOKEN_REQUEST_URL)
+	oidcTokenUrl string,
+	// GitHub Actions OIDC bearer token (ACTIONS_ID_TOKEN_REQUEST_TOKEN)
+	oidcToken *dagger.Secret,
 ) error {
 	versionNum := strings.TrimPrefix(version, "v")
 
@@ -248,17 +250,14 @@ func (m *Shipyard) PublishNPM(
 	fmt.Printf("Creating npm package...\n")
 	npmPackage := m.createNPMPackage(ctx, version)
 
-	// Publish to npm
+	// Publish to npm via OIDC trusted publishing
 	fmt.Printf("Publishing to npm...\n")
 	publisher := dag.Container().
-		From("node:20-alpine").
-		WithSecretVariable("NPM_TOKEN", npmToken).
+		From("node:lts-alpine").
+		WithEnvVariable("ACTIONS_ID_TOKEN_REQUEST_URL", oidcTokenUrl).
+		WithSecretVariable("ACTIONS_ID_TOKEN_REQUEST_TOKEN", oidcToken).
 		WithMountedDirectory("/package", npmPackage).
 		WithWorkdir("/package").
-		WithExec([]string{
-			"sh", "-c",
-			"echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc",
-		}).
 		WithExec([]string{"npm", "publish", "--access", "public"})
 
 	_, err := publisher.Sync(ctx)


### PR DESCRIPTION
## Summary

- Switch npm publishing from static `NPM_TOKEN` to OIDC trusted publishing — requires `id-token: write` and trusted publisher configured on npmjs.com
- Extend GitHub App token scope to include `homebrew-tap` repo, fixing the git auth failure (exit code 128) when updating the Homebrew formula
- Bump npm container image from `node:20-alpine` to `node:lts-alpine` (required for npm trusted publishing: npm ≥11.5.1, Node ≥22)

## Test plan

- [ ] Trigger a release tag and verify all three channels (GitHub, Homebrew, Docker, npm) publish successfully
- [ ] Confirm no `NPM_TOKEN` secret is required in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled OIDC-based trusted publishing for npm releases, removing the need for long-lived npm tokens.
  * Updated release automation permissions to include the Homebrew tap.
  * Added Snyk vulnerability scanning to CI with a high severity threshold.
* **Bug Fixes**
  * Improved release robustness by validating required OIDC publishing inputs before attempting npm publication.
* **Documentation**
  * Refreshed README header badges to include broader CI, release, coverage, and quality indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->